### PR TITLE
[fix] Image Path & Answer Path can be None

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,13 @@ Table of Contents
     
 <a href="./201801/1.unstack_column/unstack_column_quiz.Rmd" target="_blank">문제 바로 가기</a>
 
-<div>Q) 주어진 데이터셋의 학생별 성적이력을 unstack 하는 함수를 작성해주세요~</div>
+<div>Q) 주어진 데이터셋의 학생별 성적이력을 unstack 하는 함수 unstack.col을 작성해주세요~</div>
     
 <div align="center">
   <img src="./201801/1.unstack_column/unstack_column_result.PNG" alt="Quiz Image" width="50%" max-height="30%">
 </div>
 
-<a href="./201801/1.unstack_column/unstack_column_answer.R" target="_blank">정답 보기</a>
+
 </details>
 
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -101,8 +101,10 @@ def create_quizs(nodes: List[Node]) -> List[Quiz]:
 
         quiz_node = Quiz(
             int(year),
-            int(month), ". ".join(subject.split(".")), quiz["answer_path"],
-            quiz["quiz_path"], quiz["image_path"])
+            int(month), ". ".join(subject.split(".")),
+            quiz.get("answer_path", None),
+            quiz.get("quiz_path", None),
+            quiz.get("image_path", None))
         result.append(quiz_node)
 
     return result

--- a/utils/print_markdown.py
+++ b/utils/print_markdown.py
@@ -42,6 +42,9 @@ def print_month(month: int) -> str:
 
 def print_image(quiz: Quiz) -> str:
     """Returns <img tag>"""
+    if not quiz.image_path:
+        return ""
+
     template = f"""
 <div align="center">
   <img src="{quiz.image_path}" alt="Quiz Image" width="50%" max-height="30%">
@@ -53,6 +56,15 @@ def print_image(quiz: Quiz) -> str:
 def print_question(quiz: Quiz) -> str:
     """Returns a link to the question in markdown format"""
     template = f"[{quiz.subject}]({quiz.quiz_path})"
+    return template
+
+
+def print_answer(quiz: Quiz) -> str:
+    """Returns a link to the question answer"""
+    if not quiz.answer_path:
+        return ""
+
+    template = f"""<a href="{quiz.answer_path}" target="_blank">정답 보기</a>"""
     return template
 
 
@@ -68,12 +80,13 @@ def print_quiz(quiz: Quiz) -> str:
         question = f.readline().strip()
 
     image_tag = print_image(quiz)
+    answer_tag = print_answer(quiz)
 
     template = f"""<details><summary>{subject}</summary>
     {link}
 <div>{question}</div>
     {image_tag}
-<a href="{quiz.answer_path}" target="_blank">정답 보기</a>
+{answer_tag}
 </details>
 """
 


### PR DESCRIPTION
## Summary

`Quiz`가 원래

- `answer_path` 정답 경로 (이름에 `answer`가 들어가는 파일 `*_answer.R`)
- `quiz_path` 퀴즈 경로 (`*.Rmd` 인 파일)
- `image_path` 이미지 경로  (`*.png`인 파일)

를 필수로 필요로 했었는데 필수가 아니어도 되는 패치입니다.

위 파일들을 찾지 못할경우 None 값으로 받습니다.
![image](https://user-images.githubusercontent.com/2981167/34646484-69662290-f31e-11e7-9af8-9d2923bd2b73.png)


제가 처음부터 만들때 robust하게 만들지 못했네요 죄송합니다 ㅜㅜ

`None`일경우 출력하지 않습니다. 
![image](https://user-images.githubusercontent.com/2981167/34646480-5d8aa432-f31e-11e7-8420-f438171408ae.png)

확인 부탁드립니다 :+1: 